### PR TITLE
Fix messages retrieval bug in API

### DIFF
--- a/backend/core/views.py
+++ b/backend/core/views.py
@@ -37,7 +37,7 @@ class MessageView(APIView):
                 status=status.HTTP_401_UNAUTHORIZED,
             )
 
-        messages = Message.objects
+        messages = Message.objects.all()
         serializer = MessageSerializer(messages, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
## Summary
- fix MessageView.get to use `Message.objects.all()`

## Testing
- `python -m py_compile backend/core/views.py`

------
https://chatgpt.com/codex/tasks/task_e_683f3fbb4f8c8321be5dda8c14cfab0f