### PR TITLE
Fix French translation typo

### DIFF
--- a/frontend/src/components/OptionsButton.tsx
+++ b/frontend/src/components/OptionsButton.tsx
@@ -79,7 +79,7 @@ export default function OptionsButton() {
               width: "140px",
             }}
           >
-            <Typography>Déconnection</Typography>
+            <Typography>Déconnexion</Typography>
             <LogoutIcon />
           </Box>
         </MenuItem>


### PR DESCRIPTION
## Summary
- fix the logout menu item French text

## Testing
- `npm test -- --watchAll=false` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f40a1b7608321a657aadf988ef099