### PR TITLE
Add devcontainer and expand docs

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,19 @@
+{
+  "name": "Personal Website Dev Container",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/node:1": {"version": "20"},
+    "ghcr.io/devcontainers/features/python:1": {"version": "3.12"},
+    "ghcr.io/devcontainers-contrib/features/poetry:2": {}
+  },
+  "postCreateCommand": "npm install --prefix frontend && poetry install --directory backend",
+  "customizations": {
+    "vscode": {
+      "extensions": [
+        "ms-python.python",
+        "esbenp.prettier-vscode",
+        "dbaeumer.vscode-eslint"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # Personal Website for Me and My Girlfriend ❤️🌸
 
 This project consists of a **frontend** developed with **React** and a **backend** powered by **Django**.  
+## Project Overview
+
+The application is split into a React frontend and a Django backend. A Redis service handles WebSocket channels and an Nginx reverse proxy exposes both parts under a single entry point. Docker Compose orchestrates these services for both development and production deployments.
+
 It is intended for deployment via **Docker Compose** for production environments.
 
 ---
@@ -66,6 +70,7 @@ The application is containerized using **Docker Compose**.
 
 ### Required Environment Variables
 
+Before starting, create a `.env` file at the project root containing these variables.
 Before running `docker-compose up`, configure the following environment variables:
 
 | Variable            | Description                           | Example                   |
@@ -94,7 +99,7 @@ docker-compose up --build
 
 ## TODO
 
-- [ ] Add a development container (`.devcontainer/`) for VSCode integration
+- [X] Add a development container (`.devcontainer/`) for VSCode integration
 - [ ] Add a `TODO` command or page within the project for internal task tracking
 - [ ] Write full testing suites (unit and integration tests)
 - [X] Set up CI/CD (Continuous Integration and Delivery)
@@ -102,3 +107,8 @@ docker-compose up --build
 - [X] Implement user authentication and authorization
 - [X] Secure environment variables management (use `.env` file with Docker Compose)
 - [X] Configure HTTPS for production
+
+## Development with Dev Containers
+
+If you use VS Code, you can open the repository inside a container for a ready-to-use environment. The configuration lives in the `.devcontainer` directory. After opening the dev container, dependencies for both the frontend and backend will be installed automatically.
+


### PR DESCRIPTION
## Summary
- add VS Code devcontainer config
- document Docker Compose usage with .env file
- mark devcontainer TODO as done and describe the setup

## Testing
- `pip install "django>=5.2" python-dotenv pymysql channels djangorestframework djangorestframework-simplejwt django-cors-headers daphne channels-redis`
- `USE_SQLITE=True SECRET_KEY=dummy python manage.py test` *(fails: tests not discovered)*
- `npm install`
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_684099c7b4e88321ae79dd9e55bd3c2b