### PR TITLE
feat(media): serve photos through a backend proxy with resize, conver…

### DIFF
--- a/backend/backend/settings.py
+++ b/backend/backend/settings.py
@@ -195,6 +195,21 @@ CHANNEL_LAYERS = {
     },
 }
 
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.redis.RedisCache",
+        "LOCATION": f"redis://{os.getenv('REDIS_HOST', 'localhost')}:6379/1",
+        "TIMEOUT": 60 * 60 * 24 * 7,
+    }
+}
+
+# Media proxy tuning (backend-served photos)
+MEDIA_ALLOWED_WIDTHS = [240, 480, 960, 1920]  # bounds cache cardinality
+MEDIA_MAX_DIMENSION = 1920  # auto-downscale threshold for full-size requests
+MEDIA_RECOMPRESS_BYTES = 500 * 1024  # recompress originals bigger than this
+MEDIA_CACHE_MAX_BYTES = 5 * 1024 * 1024  # never cache blobs bigger than this
+MEDIA_WEBP_QUALITY = 80
+
 
 # Password validation
 # https://docs.djangoproject.com/en/5.1/ref/settings/#auth-password-validators

--- a/backend/backend/settings_test.py
+++ b/backend/backend/settings_test.py
@@ -30,3 +30,9 @@ DEBUG = False
 ALLOWED_HOSTS = ["*"]
 
 CORS_ALLOW_ALL_ORIGINS = True
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+    }
+}

--- a/backend/core/image_normalizer.py
+++ b/backend/core/image_normalizer.py
@@ -1,0 +1,48 @@
+from io import BytesIO
+
+from PIL import Image, UnidentifiedImageError
+from pillow_heif import register_heif_opener
+
+# Lets Pillow decode Apple formats (HEIC/HEIF) uploaded by iPhones
+register_heif_opener()
+
+# Formats every browser can display; anything else gets converted
+WEB_SAFE_FORMATS = {"JPEG", "PNG", "WEBP", "GIF"}
+
+JPEG_QUALITY = 88
+
+
+def normalize_to_web_format(file):
+    """Convert an uploaded image to JPEG unless it is already web-displayable.
+
+    Returns the original file untouched for web-safe formats and for
+    non-image payloads; otherwise returns a BytesIO with a .jpg name.
+    """
+    data = file.read()
+    try:
+        img = Image.open(BytesIO(data))
+        source_format = img.format
+    except (UnidentifiedImageError, TypeError):
+        # Not decodable as an image: store as-is, like before
+        file.seek(0)
+        return file
+
+    if source_format in WEB_SAFE_FORMATS:
+        file.seek(0)
+        return file
+
+    if img.mode in ("RGBA", "LA", "P"):
+        img = img.convert("RGBA")
+        background = Image.new("RGB", img.size, (255, 255, 255))
+        background.paste(img, mask=img.split()[-1])
+        img = background
+    elif img.mode != "RGB":
+        img = img.convert("RGB")
+
+    out = BytesIO()
+    img.save(out, format="JPEG", quality=JPEG_QUALITY)
+    out.seek(0)
+
+    base_name = file.name.rsplit(".", 1)[0] if "." in file.name else file.name
+    out.name = f"{base_name}.jpg"
+    return out

--- a/backend/core/interface/aws.py
+++ b/backend/core/interface/aws.py
@@ -1,4 +1,5 @@
-from core.exceptions.exceptions import CloudUploadError
+from core.exceptions.exceptions import CloudUploadError, ResourceNotFound
+from core.image_normalizer import normalize_to_web_format
 from core.interface.photo_saver_repository import PhotoSaverRepository
 import boto3
 from botocore.exceptions import NoCredentialsError, ClientError, BotoCoreError
@@ -65,6 +66,7 @@ class AwsPhotoSaver(PhotoSaverRepository):
             raise CloudUploadError("Échec de la suppression depuis S3")
 
     def save_within_folder(self, file, folder_album_id) -> str:
+        file = normalize_to_web_format(file)
         file_name = self._generate_unique_name(file.name)
 
         file_key = f"{folder_album_id}/{file_name}"
@@ -76,6 +78,7 @@ class AwsPhotoSaver(PhotoSaverRepository):
         return self._get_s3_resource_url(file_key)
 
     def save(self, file) -> str:
+        file = normalize_to_web_format(file)
         file_key = self._generate_unique_name(file.name)
 
         if DEBUG:
@@ -104,6 +107,22 @@ class AwsPhotoSaver(PhotoSaverRepository):
         file_key = self._extract_key_from_url(file_url)
 
         return self._delete_from_s3(file_key)
+
+    def fetch(self, file_url: str) -> tuple[bytes, str]:
+        file_key = self._extract_key_from_url(file_url)
+        s3 = self._get_s3_client()
+        try:
+            obj = s3.get_object(Bucket=AWS_BUCKET_NAME, Key=file_key)
+            return obj["Body"].read(), obj.get("ContentType", "application/octet-stream")
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            if error_code in ("NoSuchKey", "404"):
+                raise ResourceNotFound(f"Fichier absent de S3: {file_key}")
+            print(f"Erreur téléchargement S3: {e}")
+            raise CloudUploadError("Échec du téléchargement depuis S3")
+        except (NoCredentialsError, BotoCoreError) as e:
+            print(f"Erreur téléchargement S3: {e}")
+            raise CloudUploadError("Échec du téléchargement depuis S3")
 
     def copy_file(self, source_url: str, target_album_id) -> str:
         source_key = self._extract_key_from_url(source_url)

--- a/backend/core/interface/photo_saver_repository.py
+++ b/backend/core/interface/photo_saver_repository.py
@@ -19,3 +19,7 @@ class PhotoSaverRepository(ABC):
     @abstractmethod
     def copy_file(self, source_url: str, target_album_id) -> str:
         pass
+
+    @abstractmethod
+    def fetch(self, file_url: str) -> tuple[bytes, str]:
+        pass

--- a/backend/core/media_signing.py
+++ b/backend/core/media_signing.py
@@ -1,0 +1,14 @@
+import hashlib
+import hmac
+
+from django.conf import settings
+
+
+def sign(file_url: str) -> str:
+    return hmac.new(
+        settings.SECRET_KEY.encode(), file_url.encode(), hashlib.sha256
+    ).hexdigest()[:16]
+
+
+def verify(file_url: str, signature: str) -> bool:
+    return hmac.compare_digest(sign(file_url), signature)

--- a/backend/core/serializers/album.py
+++ b/backend/core/serializers/album.py
@@ -1,6 +1,13 @@
+import hashlib
+
 from rest_framework import serializers
 from ..models.album import Album
 from ..models.photo import Photo
+from .. import media_signing
+
+
+def media_cache_buster(file_url: str) -> str:
+    return hashlib.sha1(file_url.encode()).hexdigest()[:8]
 
 
 class AlbumSerializer(serializers.ModelSerializer):
@@ -18,6 +25,15 @@ class AlbumSerializer(serializers.ModelSerializer):
             "nb_photos",
         ]
         read_only_fields = ["created_at", "updated_at"]
+
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # The S3 URL stays in DB; the API exposes the backend media proxy instead
+        if data.get("cover_image"):
+            sig = media_signing.sign(instance.cover_image)
+            v = media_cache_buster(instance.cover_image)
+            data["cover_image"] = f"/api/media/albums/{instance.id}/cover/{sig}/?v={v}"
+        return data
 
     def get_nb_photos(self, album):
         return Photo.objects.filter(album=album).count()

--- a/backend/core/serializers/photo.py
+++ b/backend/core/serializers/photo.py
@@ -1,6 +1,7 @@
 from rest_framework import serializers
 from ..models.photo import Photo
-from .album import AlbumSerializer
+from .. import media_signing
+from .album import AlbumSerializer, media_cache_buster
 
 
 class PhotoSerializer(serializers.ModelSerializer):
@@ -25,11 +26,22 @@ class PhotoSerializer(serializers.ModelSerializer):
         if self.instance is not None:
             self.fields["image_url"].read_only = True
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # The S3 URL stays in DB; the API exposes the backend media proxy instead
+        if data.get("image_url"):
+            sig = media_signing.sign(instance.image_url)
+            v = media_cache_buster(instance.image_url)
+            data["image_url"] = f"/api/media/photos/{instance.id}/{sig}/?v={v}"
+        return data
+
     def create(self, validated_data):
         request = self.context.get("request")
         if request and not request.user.is_authenticated:
             return None
-        album = self.context.get("album")
+        # serializer.save(album=...) injects album into validated_data:
+        # pop it so it is never passed twice to objects.create()
+        album = validated_data.pop("album", None) or self.context.get("album")
         if not album:
             raise serializers.ValidationError({"album": "Album manquant"})
 

--- a/backend/core/services/__init__.py
+++ b/backend/core/services/__init__.py
@@ -3,3 +3,4 @@ from .album_service import AlbumService
 from .bucketpoints_service import BucketPointService
 from .photo_service import PhotoService
 from .user_service import UserService
+from .media_service import MediaService

--- a/backend/core/services/media_service.py
+++ b/backend/core/services/media_service.py
@@ -1,0 +1,75 @@
+import hashlib
+from io import BytesIO
+
+from django.conf import settings
+from django.core.cache import cache
+from PIL import Image, UnidentifiedImageError
+
+from core.dependencies import photo_repository
+from core.image_normalizer import WEB_SAFE_FORMATS
+
+
+class MediaService:
+
+    @staticmethod
+    def _snap_width(width):
+        if width is None:
+            return None
+        allowed = settings.MEDIA_ALLOWED_WIDTHS
+        if width >= max(allowed):
+            return None  # full size already capped at MEDIA_MAX_DIMENSION
+        return min(w for w in allowed if w >= width)
+
+    @staticmethod
+    def _cache_key(file_url: str, width) -> str:
+        digest = hashlib.sha256(file_url.encode()).hexdigest()[:32]
+        return f"media:{digest}:w{width or 'orig'}"
+
+    @classmethod
+    def get_image(cls, file_url: str, width=None) -> tuple[bytes, str]:
+        width = cls._snap_width(width)
+        cache_key = cls._cache_key(file_url, width)
+
+        cached = cache.get(cache_key)
+        if cached is not None:
+            return cached
+
+        raw, content_type = photo_repository.fetch(file_url)
+        data, content_type = cls._optimize(raw, content_type, width)
+
+        if len(data) <= settings.MEDIA_CACHE_MAX_BYTES:
+            cache.set(cache_key, (data, content_type))
+
+        return data, content_type
+
+    @staticmethod
+    def _optimize(raw: bytes, content_type: str, width) -> tuple[bytes, str]:
+        # Sniff the real format from the bytes: the S3 content type can lie
+        # (e.g. Apple HEIC files stored with a wrong name/type)
+        try:
+            img = Image.open(BytesIO(raw))
+            source_format = img.format
+        except UnidentifiedImageError:
+            return raw, content_type
+
+        # GIFs would lose animation
+        if source_format == "GIF":
+            return raw, "image/gif"
+
+        needs_convert = source_format not in WEB_SAFE_FORMATS
+        needs_recompress = len(raw) > settings.MEDIA_RECOMPRESS_BYTES
+        target = width or settings.MEDIA_MAX_DIMENSION
+        needs_resize = img.width > target or img.height > target
+
+        if not needs_convert and not needs_recompress and not needs_resize:
+            return raw, Image.MIME.get(source_format, content_type)
+
+        if needs_resize:
+            img.thumbnail((target, target), Image.LANCZOS)
+
+        if img.mode not in ("RGB", "RGBA"):
+            img = img.convert("RGB")
+
+        out = BytesIO()
+        img.save(out, format="WEBP", quality=settings.MEDIA_WEBP_QUALITY)
+        return out.getvalue(), "image/webp"

--- a/backend/core/tests/interface/test_aws.py
+++ b/backend/core/tests/interface/test_aws.py
@@ -1,7 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
 from core.interface.aws import AwsPhotoSaver
-from core.exceptions.exceptions import CloudUploadError
+from core.exceptions.exceptions import CloudUploadError, ResourceNotFound
 from botocore.exceptions import ClientError
 
 TEST_AWS_BUCKET_NAME = "testing_bucket_name"
@@ -172,3 +172,64 @@ class TestAwsPhotoSaver(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestAwsPhotoSaverFetch(unittest.TestCase):
+
+    def setUp(self):
+        self.aws_saver = AwsPhotoSaver()
+
+    @patch("core.interface.aws.boto3")
+    @patch("core.interface.aws.AWS_BUCKET_NAME", TEST_AWS_BUCKET_NAME)
+    @patch("core.interface.aws.AWS_REGION", TEST_AWS_REGION)
+    def test_givenExistingKey_whenFetch_thenShouldReturnBytesAndContentType(
+        self, mock_boto3
+    ):
+        mock_s3_client = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_body = MagicMock()
+        mock_body.read.return_value = b"image bytes"
+        mock_s3_client.get_object.return_value = {
+            "Body": mock_body,
+            "ContentType": "image/jpeg",
+        }
+
+        data, content_type = self.aws_saver.fetch(TEST_EXPECTED_URL)
+
+        self.assertEqual(data, b"image bytes")
+        self.assertEqual(content_type, "image/jpeg")
+        mock_s3_client.get_object.assert_called_once_with(
+            Bucket=TEST_AWS_BUCKET_NAME, Key=TEST_S3_KEY
+        )
+
+    @patch("core.interface.aws.boto3")
+    @patch("core.interface.aws.AWS_BUCKET_NAME", TEST_AWS_BUCKET_NAME)
+    @patch("core.interface.aws.AWS_REGION", TEST_AWS_REGION)
+    def test_givenMissingKey_whenFetch_thenShouldRaiseResourceNotFound(
+        self, mock_boto3
+    ):
+        mock_s3_client = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_s3_client.get_object.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "does not exist"}},
+            "GetObject",
+        )
+
+        with self.assertRaises(ResourceNotFound):
+            self.aws_saver.fetch(TEST_EXPECTED_URL)
+
+    @patch("core.interface.aws.boto3")
+    @patch("core.interface.aws.AWS_BUCKET_NAME", TEST_AWS_BUCKET_NAME)
+    @patch("core.interface.aws.AWS_REGION", TEST_AWS_REGION)
+    def test_givenOtherS3Error_whenFetch_thenShouldRaiseCloudUploadError(
+        self, mock_boto3
+    ):
+        mock_s3_client = MagicMock()
+        mock_boto3.client.return_value = mock_s3_client
+        mock_s3_client.get_object.side_effect = ClientError(
+            {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+            "GetObject",
+        )
+
+        with self.assertRaises(CloudUploadError):
+            self.aws_saver.fetch(TEST_EXPECTED_URL)

--- a/backend/core/tests/serializers/test_photo.py
+++ b/backend/core/tests/serializers/test_photo.py
@@ -1,5 +1,7 @@
 import unittest
 from unittest.mock import MagicMock, patch
+from core import media_signing
+from core.serializers.album import media_cache_buster
 from core.serializers.photo import PhotoSerializer
 from core.models.photo import Photo
 from core.models.album import Album
@@ -39,13 +41,18 @@ class TestPhotoSerializer(unittest.TestCase):
         mock_photo.created_at = "2023-01-01"
         mock_photo.updated_at = "2023-01-02"
         mock_photo.album = self.mock_album
+        self.mock_album.cover_image = None
 
         mock_album_photo.objects.filter.return_value.count.return_value = 0
 
         serializer = PhotoSerializer(instance=mock_photo)
         data = serializer.data
 
-        self.assertEqual(data["image_url"], TEST_IMAGE_URL)
+        expected_url = (
+            f"/api/media/photos/{TEST_PHOTO_ID}/{media_signing.sign(TEST_IMAGE_URL)}/"
+            f"?v={media_cache_buster(TEST_IMAGE_URL)}"
+        )
+        self.assertEqual(data["image_url"], expected_url)
 
     def test_givenUnauthenticatedUser_whenCreate_thenShouldReturnNone(self):
         self.mock_user.is_authenticated = False
@@ -71,6 +78,19 @@ class TestPhotoSerializer(unittest.TestCase):
         self.mock_user.is_authenticated = True
 
         self.serializer.create(TEST_VALID_DATA)
+
+        mock_create.assert_called_once_with(album=self.mock_album, **TEST_VALID_DATA)
+
+    @patch("core.serializers.photo.Photo.objects.create")
+    def test_givenAlbumInValidatedData_whenCreate_thenShouldNotPassAlbumTwice(
+        self, mock_create
+    ):
+        # serializer.save(album=...) injects album into validated_data:
+        # create() must not forward it twice to objects.create()
+        self.mock_user.is_authenticated = True
+        data_with_album = {**TEST_VALID_DATA, "album": self.mock_album}
+
+        self.serializer.create(data_with_album)
 
         mock_create.assert_called_once_with(album=self.mock_album, **TEST_VALID_DATA)
 

--- a/backend/core/tests/services/test_media_service.py
+++ b/backend/core/tests/services/test_media_service.py
@@ -1,0 +1,59 @@
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase, override_settings
+
+from core.services.media_service import MediaService
+from core.tests.views.test_media import make_image_bytes
+
+TEST_IMAGE_URL = "https://bucket.s3.eu-north-1.amazonaws.com/1/uuid_photo.jpg"
+
+
+class TestMediaService(TestCase):
+    def setUp(self):
+        cache.clear()
+
+    def test_cache_key_includes_width(self):
+        key_orig = MediaService._cache_key(TEST_IMAGE_URL, None)
+        key_480 = MediaService._cache_key(TEST_IMAGE_URL, 480)
+
+        self.assertNotEqual(key_orig, key_480)
+        self.assertTrue(key_orig.endswith(":worig"))
+        self.assertTrue(key_480.endswith(":w480"))
+
+    def test_width_snaps_to_allowed_values(self):
+        self.assertEqual(MediaService._snap_width(100), 240)
+        self.assertEqual(MediaService._snap_width(480), 480)
+        self.assertEqual(MediaService._snap_width(500), 960)
+        self.assertIsNone(MediaService._snap_width(1920))
+        self.assertIsNone(MediaService._snap_width(4000))
+        self.assertIsNone(MediaService._snap_width(None))
+
+    @override_settings(MEDIA_CACHE_MAX_BYTES=10)
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_oversized_payload_is_not_cached(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(200, 150), "image/jpeg")
+
+        MediaService.get_image(TEST_IMAGE_URL)
+        MediaService.get_image(TEST_IMAGE_URL)
+
+        self.assertEqual(mock_fetch.call_count, 2)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_large_original_is_recompressed_to_webp(self, mock_fetch):
+        with override_settings(MEDIA_RECOMPRESS_BYTES=100):
+            mock_fetch.return_value = (make_image_bytes(1000, 800), "image/jpeg")
+
+            data, content_type = MediaService.get_image(TEST_IMAGE_URL)
+
+        self.assertEqual(content_type, "image/webp")
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_non_image_content_passes_through(self, mock_fetch):
+        raw = b"%PDF-1.4 not an image"
+        mock_fetch.return_value = (raw, "application/pdf")
+
+        data, content_type = MediaService.get_image(TEST_IMAGE_URL, 480)
+
+        self.assertEqual(data, raw)
+        self.assertEqual(content_type, "application/pdf")

--- a/backend/core/tests/utils/test_image_normalizer.py
+++ b/backend/core/tests/utils/test_image_normalizer.py
@@ -1,0 +1,60 @@
+from io import BytesIO
+
+from django.test import TestCase
+from PIL import Image
+
+from core.image_normalizer import normalize_to_web_format
+
+
+def make_upload(fmt="JPEG", name="photo.jpg", width=200, height=150, mode="RGB"):
+    img = Image.new(mode, (width, height), color=(120, 30, 60) if mode == "RGB" else None)
+    out = BytesIO()
+    img.save(out, format=fmt)
+    out.seek(0)
+    out.name = name
+    return out
+
+
+class TestNormalizeToWebFormat(TestCase):
+    def test_jpeg_passes_through_untouched(self):
+        upload = make_upload(fmt="JPEG", name="photo.jpg")
+
+        result = normalize_to_web_format(upload)
+
+        self.assertIs(result, upload)
+        self.assertEqual(result.tell(), 0)
+
+    def test_webp_passes_through_untouched(self):
+        upload = make_upload(fmt="WEBP", name="photo.webp")
+
+        result = normalize_to_web_format(upload)
+
+        self.assertIs(result, upload)
+
+    def test_heic_is_converted_to_jpeg(self):
+        upload = make_upload(fmt="HEIF", name="IMG_1234.heic")
+
+        result = normalize_to_web_format(upload)
+
+        self.assertIsNot(result, upload)
+        self.assertEqual(result.name, "IMG_1234.jpg")
+        img = Image.open(result)
+        self.assertEqual(img.format, "JPEG")
+
+    def test_transparent_image_is_flattened_on_white(self):
+        upload = make_upload(fmt="HEIF", name="logo.heic", mode="RGBA")
+
+        result = normalize_to_web_format(upload)
+
+        img = Image.open(result)
+        self.assertEqual(img.format, "JPEG")
+        self.assertEqual(img.mode, "RGB")
+
+    def test_non_image_passes_through_untouched(self):
+        upload = BytesIO(b"not an image at all")
+        upload.name = "document.pdf"
+
+        result = normalize_to_web_format(upload)
+
+        self.assertIs(result, upload)
+        self.assertEqual(result.tell(), 0)

--- a/backend/core/tests/views/test_media.py
+++ b/backend/core/tests/views/test_media.py
@@ -1,0 +1,176 @@
+from io import BytesIO
+from unittest.mock import patch
+
+from django.core.cache import cache
+from django.test import TestCase
+from PIL import Image
+from rest_framework import status
+from rest_framework.test import APIRequestFactory
+
+from core import media_signing
+from core.exceptions.exceptions import CloudUploadError, ResourceNotFound
+from core.models import Album, Photo
+from core.views.media import MediaPhotoView, MediaAlbumCoverView
+
+TEST_IMAGE_URL = "https://bucket.s3.eu-north-1.amazonaws.com/1/uuid_photo.jpg"
+TEST_COVER_URL = "https://bucket.s3.eu-north-1.amazonaws.com/uuid_cover.jpg"
+
+
+def make_image_bytes(width=2000, height=1500, fmt="JPEG"):
+    img = Image.new("RGB", (width, height), color=(120, 30, 60))
+    out = BytesIO()
+    img.save(out, format=fmt)
+    return out.getvalue()
+
+
+class TestMediaPhotoView(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+        self.view = MediaPhotoView.as_view()
+        self.album = Album.objects.create(title="Album", description="d")
+        self.photo = Photo.objects.create(album=self.album, image_url=TEST_IMAGE_URL)
+        self.sig = media_signing.sign(TEST_IMAGE_URL)
+
+    def _get(self, path_suffix="", sig=None, photo_id=None):
+        sig = sig or self.sig
+        photo_id = photo_id or self.photo.id
+        request = self.factory.get(f"/media/photos/{photo_id}/{sig}/{path_suffix}")
+        return self.view(request, photo_id=photo_id, sig=sig)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_returns_image_with_cache_headers(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(), "image/jpeg")
+
+        response = self._get()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(
+            response["Cache-Control"], "public, max-age=31536000, immutable"
+        )
+        mock_fetch.assert_called_once_with(TEST_IMAGE_URL)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_width_param_resizes_to_webp(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(2000, 1500), "image/jpeg")
+
+        response = self._get("?w=480")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "image/webp")
+        img = Image.open(BytesIO(response.content))
+        self.assertLessEqual(img.width, 480)
+        self.assertLessEqual(img.height, 480)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_small_image_passes_through_unmodified(self, mock_fetch):
+        raw = make_image_bytes(200, 150)
+        mock_fetch.return_value = (raw, "image/jpeg")
+
+        response = self._get()
+
+        self.assertEqual(response.content, raw)
+        self.assertEqual(response["Content-Type"], "image/jpeg")
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_heic_is_converted_to_webp_even_when_small(self, mock_fetch):
+        # Apple HEIC stored with a lying content type must still be converted
+        raw = make_image_bytes(200, 150, fmt="HEIF")
+        mock_fetch.return_value = (raw, "application/octet-stream")
+
+        response = self._get()
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response["Content-Type"], "image/webp")
+        img = Image.open(BytesIO(response.content))
+        self.assertEqual(img.format, "WEBP")
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_gif_passes_through_unmodified(self, mock_fetch):
+        raw = make_image_bytes(2000, 1500, fmt="GIF")
+        mock_fetch.return_value = (raw, "image/gif")
+
+        response = self._get("?w=480")
+
+        self.assertEqual(response.content, raw)
+        self.assertEqual(response["Content-Type"], "image/gif")
+
+    def test_invalid_width_returns_400(self):
+        for bad_width in ["abc", "-1", "0", "9999"]:
+            response = self._get(f"?w={bad_width}")
+            self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_file_missing_on_s3_returns_404(self, mock_fetch):
+        mock_fetch.side_effect = ResourceNotFound("Fichier absent de S3")
+
+        response = self._get()
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_s3_failure_returns_503(self, mock_fetch):
+        mock_fetch.side_effect = CloudUploadError("S3 injoignable")
+
+        response = self._get()
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+
+    def test_unknown_photo_returns_404(self):
+        response = self._get(photo_id=9999)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_tampered_signature_returns_403(self):
+        response = self._get(sig="0" * 16)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_download_param_sets_content_disposition(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(200, 150), "image/jpeg")
+
+        response = self._get("?download=1")
+
+        self.assertEqual(response["Content-Disposition"], "attachment")
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_second_call_is_served_from_cache(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(200, 150), "image/jpeg")
+
+        first = self._get()
+        second = self._get()
+
+        self.assertEqual(first.content, second.content)
+        mock_fetch.assert_called_once()
+
+
+class TestMediaAlbumCoverView(TestCase):
+    def setUp(self):
+        cache.clear()
+        self.factory = APIRequestFactory()
+        self.view = MediaAlbumCoverView.as_view()
+        self.album = Album.objects.create(
+            title="Album", description="d", cover_image=TEST_COVER_URL
+        )
+        self.sig = media_signing.sign(TEST_COVER_URL)
+
+    def _get(self, album_id, sig):
+        request = self.factory.get(f"/media/albums/{album_id}/cover/{sig}/")
+        return self.view(request, album_id=album_id, sig=sig)
+
+    @patch("core.services.media_service.photo_repository.fetch")
+    def test_returns_cover_image(self, mock_fetch):
+        mock_fetch.return_value = (make_image_bytes(200, 150), "image/jpeg")
+
+        response = self._get(self.album.id, self.sig)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        mock_fetch.assert_called_once_with(TEST_COVER_URL)
+
+    def test_unknown_album_returns_404(self):
+        response = self._get(9999, self.sig)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_album_without_cover_returns_404(self):
+        bare_album = Album.objects.create(title="NoCover", description="d")
+        response = self._get(bare_album.id, self.sig)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/backend/core/urls.py
+++ b/backend/core/urls.py
@@ -10,6 +10,8 @@ from .views import (
     PhotoDetailView,
     PhotoMoveView,
     PhotoCopyView,
+    MediaPhotoView,
+    MediaAlbumCoverView,
 )
 
 urlpatterns = [
@@ -41,5 +43,15 @@ urlpatterns = [
         "photos/<int:album_id>/<int:photo_id>/copy/",
         PhotoCopyView.as_view(),
         name="photo_copy",
+    ),
+    path(
+        "media/photos/<int:photo_id>/<str:sig>/",
+        MediaPhotoView.as_view(),
+        name="media_photo",
+    ),
+    path(
+        "media/albums/<int:album_id>/cover/<str:sig>/",
+        MediaAlbumCoverView.as_view(),
+        name="media_album_cover",
     ),
 ]

--- a/backend/core/views/__init__.py
+++ b/backend/core/views/__init__.py
@@ -3,3 +3,4 @@ from .messages import MessageView, PaginatedMessageView
 from .bucketpoints import BucketPointView
 from .albums import AlbumView
 from .photos import PhotoView, PhotoDetailView, PhotoMoveView, PhotoCopyView
+from .media import MediaPhotoView, MediaAlbumCoverView

--- a/backend/core/views/media.py
+++ b/backend/core/views/media.py
@@ -1,0 +1,61 @@
+from django.http import HttpResponse
+from rest_framework.views import APIView
+from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+
+from core.models.photo import Photo
+from core.models.album import Album
+from core.services.media_service import MediaService
+from core import media_signing
+
+ONE_YEAR = 31536000
+
+
+class BaseMediaView(APIView):
+    # Public endpoint: <img> tags cannot send the JWT Authorization header.
+    # Access control relies on the HMAC signature embedded in the URL,
+    # which matches the opacity of the previous public S3 uuid URLs.
+    authentication_classes = []
+    permission_classes = []
+
+    def _serve(self, request, file_url, signature):
+        if not media_signing.verify(file_url, signature):
+            raise PermissionDenied("Invalid signature")
+
+        width = request.query_params.get("w")
+        if width is not None:
+            try:
+                width = int(width)
+            except ValueError:
+                raise ValidationError({"w": "invalid width"})
+            if not 0 < width <= 4096:
+                raise ValidationError({"w": "invalid width"})
+
+        data, content_type = MediaService.get_image(file_url, width)
+
+        response = HttpResponse(data, content_type=content_type)
+        response["Cache-Control"] = f"public, max-age={ONE_YEAR}, immutable"
+        if request.query_params.get("download"):
+            response["Content-Disposition"] = "attachment"
+        return response
+
+
+class MediaPhotoView(BaseMediaView):
+
+    def get(self, request, photo_id, sig):
+        try:
+            photo = Photo.objects.get(pk=photo_id)
+        except Photo.DoesNotExist:
+            raise NotFound("Photo introuvable")
+        return self._serve(request, photo.image_url, sig)
+
+
+class MediaAlbumCoverView(BaseMediaView):
+
+    def get(self, request, album_id, sig):
+        try:
+            album = Album.objects.get(pk=album_id)
+        except Album.DoesNotExist:
+            raise NotFound("Album introuvable")
+        if not album.cover_image:
+            raise NotFound("Album sans couverture")
+        return self._serve(request, album.cover_image, sig)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
 
   redis:
     image: redis:7
+    command: redis-server --maxmemory 256mb --maxmemory-policy allkeys-lru
     ports:
       - "6379:6379"
     networks:

--- a/frontend/src/components/AlbumCard.tsx
+++ b/frontend/src/components/AlbumCard.tsx
@@ -2,6 +2,7 @@ import React from "react"
 import { Card, CardContent, CardMedia, Typography, CardActionArea, Box } from "@mui/material"
 import HideImageIcon from "@mui/icons-material/HideImage"
 import { Album } from "../types/album"
+import mediaUrl from "../utils/mediaUrl"
 import AlbumEditModal from "./UpdateAlbumModal"
 import { useNavigate } from "react-router-dom"
 
@@ -37,7 +38,7 @@ function AlbumCard({ album }: { album: Album }) {
                         <CardMedia
                             component="img"
                             height="180"
-                            image={album.cover_image}
+                            image={mediaUrl(album.cover_image, { w: 480 })}
                             alt={`Couverture de l'album ${album.title}`}
                             sx={{ objectFit: "cover", height: "100%" }}
                         />

--- a/frontend/src/components/PhotoCard.tsx
+++ b/frontend/src/components/PhotoCard.tsx
@@ -26,6 +26,7 @@ import DriveFileMoveIcon from "@mui/icons-material/DriveFileMove"
 import ContentCopyIcon from "@mui/icons-material/ContentCopy"
 import EditIcon from "@mui/icons-material/Edit"
 import { Photo } from "../types/photo"
+import mediaUrl from "../utils/mediaUrl"
 import { IAlbum } from "../types/album"
 import {
     useDeletePhotoMutation,
@@ -164,7 +165,7 @@ const PhotoCard = ({ photo, albumId }: PhotoCardProps) => {
                 {photo.image_url ? (
                     <CardMedia
                         component="img"
-                        image={photo.image_url}
+                        image={mediaUrl(photo.image_url, { w: 480 })}
                         alt={photo.caption || "Photo"}
                         sx={{
                             width: "100%",
@@ -457,7 +458,7 @@ const PhotoCard = ({ photo, albumId }: PhotoCardProps) => {
                         {/* Download button */}
                         <Box
                             component="a"
-                            href={photo.image_url}
+                            href={mediaUrl(photo.image_url, { download: true })}
                             download
                             sx={{
                                 backgroundColor: "rgba(0,0,0,0.6)",
@@ -510,7 +511,7 @@ const PhotoCard = ({ photo, albumId }: PhotoCardProps) => {
                     >
                         <Box
                             component="img"
-                            src={photo.image_url}
+                            src={mediaUrl(photo.image_url)}
                             alt={photo.caption || "Photo"}
                             sx={{
                                 width: "100%",

--- a/frontend/src/utils/mediaUrl.ts
+++ b/frontend/src/utils/mediaUrl.ts
@@ -1,0 +1,17 @@
+import getBaseURL from "./utils"
+
+// The API returns media paths like /api/media/photos/<id>/<sig>/?v=...
+// In dev the backend lives on another origin (REACT_APP_API_URL); in prod
+// nginx serves both under the same origin.
+function apiOrigin(): string {
+    return process.env.NODE_ENV === "development"
+        ? new URL(process.env.REACT_APP_API_URL as string).origin
+        : getBaseURL()
+}
+
+export default function mediaUrl(path: string, opts?: { w?: number; download?: boolean }): string {
+    const url = new URL(path, apiOrigin())
+    if (opts?.w) url.searchParams.set("w", String(opts.w))
+    if (opts?.download) url.searchParams.set("download", "1")
+    return url.toString()
+}

--- a/nginx.conf
+++ b/nginx.conf
@@ -23,6 +23,8 @@ http {
         server backend:8000;
     }
 
+    proxy_cache_path /var/cache/nginx/media levels=1:2 keys_zone=media_cache:10m max_size=500m inactive=7d use_temp_path=off;
+
     server {
         listen 80;
         server_name localhost;
@@ -31,6 +33,18 @@ http {
             alias /app/static/;
             access_log off;
             expires 1y;
+        }
+
+        location /api/media/ {
+            proxy_pass http://backend/api/media/;
+            proxy_http_version 1.1;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_cache media_cache;
+            proxy_cache_valid 200 7d;
+            proxy_cache_key $uri$is_args$args;
+            add_header X-Cache-Status $upstream_cache_status;
         }
 
         location /api/ {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,8 @@ dependencies = [
     "channels-redis>=4.2.1",
     "boto3>=1.39.15",
     "black>=26.1.0",
+    "pillow>=12.2.0",
+    "pillow-heif>=1.4.0",
 ]
 
 [dependency-groups]

--- a/uv.lock
+++ b/uv.lock
@@ -71,6 +71,8 @@ dependencies = [
     { name = "django-cors-headers" },
     { name = "djangorestframework" },
     { name = "djangorestframework-simplejwt" },
+    { name = "pillow" },
+    { name = "pillow-heif" },
     { name = "pymysql" },
     { name = "python-dotenv" },
 ]
@@ -96,6 +98,8 @@ requires-dist = [
     { name = "django-cors-headers", specifier = ">=4.7.0" },
     { name = "djangorestframework", specifier = ">=3.16.0" },
     { name = "djangorestframework-simplejwt", specifier = ">=5.5.0" },
+    { name = "pillow", specifier = ">=12.2.0" },
+    { name = "pillow-heif", specifier = ">=1.4.0" },
     { name = "pymysql", specifier = ">=1.1.1" },
     { name = "python-dotenv", specifier = ">=1.2.2" },
 ]
@@ -770,6 +774,45 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/e4/4b64a97d71b2a83158134abbb2f5bd3f8a2ea691361282f010998f339ec7/pillow-12.2.0-cp314-cp314t-win32.whl", hash = "sha256:6bb77b2dcb06b20f9f4b4a8454caa581cd4dd0643a08bacf821216a16d9c8354", size = 6482084, upload-time = "2026-04-01T14:45:47.568Z" },
     { url = "https://files.pythonhosted.org/packages/ba/13/306d275efd3a3453f72114b7431c877d10b1154014c1ebbedd067770d629/pillow-12.2.0-cp314-cp314t-win_amd64.whl", hash = "sha256:6562ace0d3fb5f20ed7290f1f929cae41b25ae29528f2af1722966a0a02e2aa1", size = 7225152, upload-time = "2026-04-01T14:45:50.032Z" },
     { url = "https://files.pythonhosted.org/packages/ff/6e/cf826fae916b8658848d7b9f38d88da6396895c676e8086fc0988073aaf8/pillow-12.2.0-cp314-cp314t-win_arm64.whl", hash = "sha256:aa88ccfe4e32d362816319ed727a004423aab09c5cea43c01a4b435643fa34eb", size = 2556579, upload-time = "2026-04-01T14:45:52.529Z" },
+]
+
+[[package]]
+name = "pillow-heif"
+version = "1.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pillow" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e3/5f/4753689400e657ca5d984f5e897657dab12d91b62f1bb6a1e73487b59a97/pillow_heif-1.4.0.tar.gz", hash = "sha256:55a7c0cb5321538d1ca74037be54b48d147017735a766eb29bcca4761253a1f1", size = 17127538, upload-time = "2026-06-10T16:02:40.009Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/ba/1a8f5a42c14cf8ad7c7a6b459de33e2bbd693a15690802463b370ee578cd/pillow_heif-1.4.0-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:5c6181fb25c7d28f98702160b98967d1d7d432d71decac9351f5a47ee33554e0", size = 4730173, upload-time = "2026-06-10T16:01:23.282Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/64/e659dd4a9b54ad148b8e753df6c9b84e0140065bebb69665b583b53804a8/pillow_heif-1.4.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ade286eeadb361773604e294f98c4a1b64b577aca271faa6971e2fbd018918c7", size = 3955563, upload-time = "2026-06-10T16:01:24.75Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/48/73336f6b4c6532ca98025a8c1a0254882d52c93ce7cc377440234fa20317/pillow_heif-1.4.0-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:972c68fae8379c158aad222defa8b8f10c858a5f7f9cc99942f34b9667a516cd", size = 6249338, upload-time = "2026-06-10T16:01:27.247Z" },
+    { url = "https://files.pythonhosted.org/packages/06/7a/e8053fa5e31f5f330ad1e9eec77625ba7ce97a1e765e5e05c85bf65d574a/pillow_heif-1.4.0-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cfcd611a09dbb949715d5f25063bd3668e0daa06b53a3ed5bbd92d36b4f6b2a9", size = 5664216, upload-time = "2026-06-10T16:01:29.074Z" },
+    { url = "https://files.pythonhosted.org/packages/23/e8/76f6ab993238c9d7da53fb64e588fd37ef7b603895b2383f1cbccc209233/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:08026afd5f90628e029fe88aaa222280428ba7cc485a7cae553e78f7bb289b74", size = 7336120, upload-time = "2026-06-10T16:01:30.796Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/45/d77ad6de495dfcc55be00a48434183abd7cf8e3416916236e29d0ecd95b6/pillow_heif-1.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:c8d001996e3a4687551385c2fe4d3fb84293727052fca1c0f50528c78b8327c7", size = 6597816, upload-time = "2026-06-10T16:01:32.773Z" },
+    { url = "https://files.pythonhosted.org/packages/99/ef/f240ce0e84a6d0cf8dfee1834b4aec29f209c08e3d2047196cee65527fb7/pillow_heif-1.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:107d598a1b1694ba6f371927ffd6d72d6f9af2ca4082577d9edbfdeed465f940", size = 6514536, upload-time = "2026-06-10T16:01:34.571Z" },
+    { url = "https://files.pythonhosted.org/packages/79/d4/d15e568b61f6020b1a772174b5c9c60341a1f0130951c518d33461b36bf8/pillow_heif-1.4.0-cp313-cp313-macosx_10_15_x86_64.whl", hash = "sha256:c699f8a3e845839bba590d3459ce59dba16c82c38e799955bef7042c54443eba", size = 4730166, upload-time = "2026-06-10T16:01:36.594Z" },
+    { url = "https://files.pythonhosted.org/packages/55/c0/e4d9b5570ee70f12c817722df398cdcba7fb25f4ddc691a79008a31c653d/pillow_heif-1.4.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:8f90b500ec1ae3a59d6613fd96123de35457f69fb9b3cd314d4b5a6799ba9843", size = 3955577, upload-time = "2026-06-10T16:01:38.13Z" },
+    { url = "https://files.pythonhosted.org/packages/17/75/717a3ac5edf3b5c027659c59bbd09f731708e76eab03a7bcd89d68edefd7/pillow_heif-1.4.0-cp313-cp313-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d6d907f454afa1958a688902e53f50ed7a98c8cbd6261d20f84b15e25f068020", size = 6249393, upload-time = "2026-06-10T16:01:40.398Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/ba/9d1336b1c5a6d2b7098cc851fcd3dbb5f25e37f942f327a404b2c8e0205d/pillow_heif-1.4.0-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:be955358e501ab03cd83331a49d331c16b8ea1a4f5751d46c24e6b28d8aa6a56", size = 5664268, upload-time = "2026-06-10T16:01:42.018Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/63/8382df95a9b20d295742f19a54fc8f66c438362b841c416786b4f9a5c3e1/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:1207b6b0819654262811a0cb74730cca1ced1ab7786a0fcd92f55b84ca07a05c", size = 7336108, upload-time = "2026-06-10T16:01:44.682Z" },
+    { url = "https://files.pythonhosted.org/packages/da/72/fbcbfac3ee43f8da79b1c6a8cbd62c2b9ee49ae069548029715c5a3fdc55/pillow_heif-1.4.0-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:cdd3ebd552b50d0221bf525e033fbe3e83130b05c81bfd53d50ed4eafbb77a7c", size = 6597858, upload-time = "2026-06-10T16:01:46.501Z" },
+    { url = "https://files.pythonhosted.org/packages/df/4b/3250c23b53f3ae0b39000da6bc517f2762600516f1d44549c9eb65657587/pillow_heif-1.4.0-cp313-cp313-win_amd64.whl", hash = "sha256:19a2d9bd52b1f6dabed5305b8b5c4962b2bf7c21e8195c909e9425e4ca8ebf72", size = 6514532, upload-time = "2026-06-10T16:01:48.646Z" },
+    { url = "https://files.pythonhosted.org/packages/44/bf/2d210965f010ed3e88c03530137ce03aeb9e1e1306e5815b49d0d3b9e2f0/pillow_heif-1.4.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:4849dfceeec19d12c819bd12e138f91f1aa181eb2fd21231644bda91d2d0b292", size = 4730182, upload-time = "2026-06-10T16:01:50.45Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/d3/64818f50ff63066c2fbbbd2eecef7acd774bc96a9ac9b672df9175cb0ecb/pillow_heif-1.4.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:d9d05477d67b3d63d601254ddca6b1e1943b0f5e5934cb5ed123c9b89e0fc60d", size = 3955616, upload-time = "2026-06-10T16:01:52.593Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/d2/ae19025e45149a7b974a4bfcf6a522b3359c7ae8afb48cce57204a0d7be9/pillow_heif-1.4.0-cp314-cp314-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:93de4bdb496c5f509911b57b057c16ec1ed10f3617b87f03f7f152745758691b", size = 6249592, upload-time = "2026-06-10T16:02:07.409Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/9b/431f3080133849ee3d2a497b4097238ba9786ba64e30820563f07c8c9a18/pillow_heif-1.4.0-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6789fc4fe9ffa7beafcf0e287ea355de3a3c0c84e3adfabbbfdf8b46b83f223a", size = 5664277, upload-time = "2026-06-10T16:02:09.347Z" },
+    { url = "https://files.pythonhosted.org/packages/30/bb/2e8578747987dd4c0d3289ca9ae8d9669c55cc5055bb0ccf39191b6b0338/pillow_heif-1.4.0-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:b31a152471c757eb02b71c9944a5973b818a21dea7980bfc57fe13945d051326", size = 7336225, upload-time = "2026-06-10T16:02:11.611Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f4/d6ddf033215a7d4b5a2ddcac423d6243bb13aae021d856028e6205ea62f1/pillow_heif-1.4.0-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a3debca82964ba4080277620601f274a8c9d509d52fd3e1faacb314dc0678ee4", size = 6597937, upload-time = "2026-06-10T16:02:13.619Z" },
+    { url = "https://files.pythonhosted.org/packages/28/6c/170e91115a5825b646fcb40cae9cd0c8977482588f667ad22981dc0ebe4c/pillow_heif-1.4.0-cp314-cp314-win_amd64.whl", hash = "sha256:4bd30446e025e682ac1450446e0b9a9a06efc27b5417c81b18d26aa40b97cd70", size = 6698362, upload-time = "2026-06-10T16:02:15.48Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/6c/b7e21b57479a159157e944da641dc2112b432c4ef421c43c02a9c87580a8/pillow_heif-1.4.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:9299b4e6cfa3d49c0495680011d224db69e41687c0e2de81a38ea6c39276e15b", size = 4731147, upload-time = "2026-06-10T16:02:17.24Z" },
+    { url = "https://files.pythonhosted.org/packages/43/6b/efb46f9f7c4a152ad1db194388f490b5c13f5fd11132aef99ba6c4e57e60/pillow_heif-1.4.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6b772360a412df897ed59d56d2ef30d52b6cce7c3f7b8b170a9578deb311953b", size = 3956423, upload-time = "2026-06-10T16:02:18.797Z" },
+    { url = "https://files.pythonhosted.org/packages/56/1d/077278664d25759957ed2d16e2a777a0ecaf3629059bea4e5fc796e4e9db/pillow_heif-1.4.0-cp314-cp314t-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ffbed970ea96485f96874604d3df298c06e89475dea09c217b8b901cc7ed7d1a", size = 6254712, upload-time = "2026-06-10T16:02:20.454Z" },
+    { url = "https://files.pythonhosted.org/packages/77/1f/20f28434f4ea119c34c98d3f3b3950236471a5cf5c5c8d47b400d1bfa2b2/pillow_heif-1.4.0-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f75faab30c0b1f20d266e0c8a1a746f7aa56694baf3fd5cc4d86f2f242bb58de", size = 5668435, upload-time = "2026-06-10T16:02:22.391Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/39/79a1e3b3d8a09fc618f5ecb984170d716b812fba7342f3246524a9c829e7/pillow_heif-1.4.0-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:500bc4ea048ed8f2e7167451737539c2763c2d157357d1706024b2a9e6910c61", size = 7341339, upload-time = "2026-06-10T16:02:24.566Z" },
+    { url = "https://files.pythonhosted.org/packages/95/52/e72d34251e4712e4591b245aa3888beaee750894c6f7777d7505695ee364/pillow_heif-1.4.0-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:387b16e826ec29ab31101f257f362ed33e9b6aecec77d4f7d19caeb33fed0f1a", size = 6602011, upload-time = "2026-06-10T16:02:26.426Z" },
+    { url = "https://files.pythonhosted.org/packages/68/36/03647089e0dc9ccdeb0de2653b549ff83c414fa0a5799d56b994b1894a0e/pillow_heif-1.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:84f138c31d34a8bab5ffa07ffbcf9b865b8ad34e6c495dcb6e01fb29574e218d", size = 6698960, upload-time = "2026-06-10T16:02:28.198Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Issue: #51

This pull request introduces a comprehensive backend media proxy for serving photo files, with robust image normalization, caching, and API exposure improvements. Uploaded images are now automatically converted to web-safe formats, backend-served media URLs are returned from the API instead of direct S3 links, and a new `MediaService` efficiently handles image resizing, recompression, and caching. The S3 interface is extended with fetch capabilities, and all changes are covered by new or updated tests.

**Backend media proxy and image handling improvements:**

* Added `MediaService` (`backend/core/services/media_service.py`) to fetch, resize, recompress, convert, and cache images for efficient backend-served media endpoints. This includes logic to snap requested widths to allowed values, avoid caching large blobs, and always serve web-safe formats.
* Introduced `normalize_to_web_format` in `core/image_normalizer.py` to convert uploaded images to JPEG unless already web-safe, including support for Apple HEIC/HEIF formats.

**API and serializer changes:**

* Updated `PhotoSerializer` and `AlbumSerializer` to expose backend media proxy URLs (e.g., `/api/media/photos/...`) instead of S3 URLs, including HMAC signatures and cache-busting hashes. 
* Added `media_signing` utility for HMAC-based URL signatures and cache busting. 
**S3 interface and caching:**

* Extended `AwsPhotoSaver` with a `fetch` method to download files from S3, with error handling for missing or inaccessible files. Updated the repository interface accordingly.
* Configured Redis caching for production and local memory cache for tests in Django settings, with media cache tuning parameters.

**Testing and validation:**

* Added and updated tests for S3 fetch, media service caching and optimization, serializer output, and correct album handling in photo creation. 
These changes lay the foundation for secure, efficient, and format-consistent media delivery through the backend API, while ensuring robust error handling and test coverage.…sion and caching

The frontend no longer loads images directly from S3 — the backend fetches, optimizes and serves them via /api/media/... endpoints.

Backend:
- New media endpoints streaming S3 objects (boto3), protected by non-expiring HMAC signatures (public but opaque URLs, matching the previous public-bucket posture)
- On-the-fly optimization with Pillow: thumbnails via ?w= (grid uses 480px), WebP recompression above 500KB, full-size capped at 1920px
- Apple HEIC/HEIF support (pillow-heif): real format sniffed from the bytes, non-web formats converted to WebP on the way out and normalized to JPEG at upload time
- Redis cache for processed images (7d TTL, LRU 256MB) + immutable HTTP cache headers; optional nginx proxy cache on /api/media/
- Serializers rewrite image_url/cover_image to proxy paths (S3 URLs stay untouched in DB)

Frontend:
- New mediaUrl() helper; grid/covers request 480px thumbnails, zoom requests full size, download button goes through the backend

Fixes:
- Photos whose S3 object was deleted now return 404 instead of 503
- Photo upload no longer crashes with "multiple values for keyword 'album'" (album was passed both via serializer.save() and context)

Tests: 247 passing (30+ new: media views, media service, image normalizer, S3 fetch, serializer regressions)