### PR TITLE
feat(realtime): live-sync albums and photos across clients via WebSocket

### DIFF
--- a/backend/core/services/album_service.py
+++ b/backend/core/services/album_service.py
@@ -1,7 +1,10 @@
 from ..models import Album
 from ..serializers import AlbumSerializer
 from core.dependencies import photo_repository
-from rest_framework.exceptions import NotFound, ValidationError
+from core.websocket.utils import send_ws_message_to_user
+from core.websocket.messages import WebSocketMessageType
+from django.contrib.auth.models import User
+from rest_framework.exceptions import ValidationError
 from django.shortcuts import get_object_or_404
 
 
@@ -25,14 +28,17 @@ class AlbumService:
             raise ValidationError(serializer.errors)
 
         serializer.save()
+
+        AlbumService._broadcast_change(
+            WebSocketMessageType.ALBUM_CREATED, {"data": serializer.data}
+        )
         return serializer.data
 
     @staticmethod
     def _replace_cover_image(data, album, file):
         if album.cover_image and album.cover_image != "":
             photo_repository.delete(album.cover_image)
-            link = photo_repository.save(file["image"])
-            data["cover_image"] = link
+        data["cover_image"] = photo_repository.save(file["image"])
         return data
 
     @classmethod
@@ -40,15 +46,27 @@ class AlbumService:
         data = raw_data.copy()
         album = get_object_or_404(Album, pk=id)
 
-        if not "image" in file or not file["image"]:
-            raise NotFound("Image not found.")
+        # The cover image is optional: a PUT without image only
+        # updates the other fields (title, description...)
+        if "image" in file and file["image"]:
+            data = cls._replace_cover_image(data, album, file)
 
-        data = cls._replace_cover_image(data, album, file)
         serializer = AlbumSerializer(album, data=data, partial=True)
 
         if not serializer.is_valid():
             raise ValidationError(serializer.errors)
 
         serializer.save()
-        # TODO: Use websockets to notify other users about the new album
+
+        cls._broadcast_change(
+            WebSocketMessageType.ALBUM_UPDATED, {"data": serializer.data}
+        )
         return serializer.data
+
+    @staticmethod
+    def _broadcast_change(message_type: WebSocketMessageType, message_data: dict):
+        """Broadcast an album change to all authenticated users."""
+        recipients = User.objects.all().values_list("id", flat=True)
+
+        for uid in recipients:
+            send_ws_message_to_user(uid, message_type, message_data)

--- a/backend/core/tests/services/test_album_service.py
+++ b/backend/core/tests/services/test_album_service.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock, patch
 from rest_framework.exceptions import ValidationError, NotFound
 
 from core.services.album_service import AlbumService
+from core.websocket.messages import WebSocketMessageType
 
 TEST_ALBUM_ID = 1
 TEST_ALBUM_TITLE = "Summer Vacation"
@@ -58,6 +59,14 @@ class TestAlbumServiceCreateAlbum(unittest.TestCase):
             "cover_image": TEST_COVER_IMAGE_URL,
             "nb_photos": 0,
         }
+
+        ws_patcher = patch("core.services.album_service.send_ws_message_to_user")
+        user_patcher = patch("core.services.album_service.User")
+        self.mock_ws_send = ws_patcher.start()
+        mock_user_model = user_patcher.start()
+        mock_user_model.objects.all.return_value.values_list.return_value = [1, 2]
+        self.addCleanup(ws_patcher.stop)
+        self.addCleanup(user_patcher.stop)
 
     @patch("core.services.album_service.AlbumSerializer")
     @patch("core.services.album_service.photo_repository")
@@ -154,6 +163,39 @@ class TestAlbumServiceCreateAlbum(unittest.TestCase):
             AlbumService.createAlbum({}, self.empty_file_dict)
 
 
+class TestAlbumServiceCreateAlbumBroadcast(unittest.TestCase):
+    """Tests for the ALBUM_CREATED WebSocket broadcast."""
+
+    def setUp(self):
+        self.serialized_data = {"id": TEST_ALBUM_ID, "title": TEST_ALBUM_TITLE}
+
+        ws_patcher = patch("core.services.album_service.send_ws_message_to_user")
+        user_patcher = patch("core.services.album_service.User")
+        self.mock_ws_send = ws_patcher.start()
+        mock_user_model = user_patcher.start()
+        mock_user_model.objects.all.return_value.values_list.return_value = [1, 2]
+        self.addCleanup(ws_patcher.stop)
+        self.addCleanup(user_patcher.stop)
+
+    @patch("core.services.album_service.AlbumSerializer")
+    @patch("core.services.album_service.photo_repository")
+    def test_createAlbum_broadcasts_album_created_event(
+        self, mock_photo_repo, mock_serializer_class
+    ):
+        mock_serializer = MagicMock()
+        mock_serializer.is_valid.return_value = True
+        mock_serializer.data = self.serialized_data
+        mock_serializer_class.return_value = mock_serializer
+
+        AlbumService.createAlbum({"title": TEST_ALBUM_TITLE}, {})
+
+        # Broadcast to the 2 mocked users
+        self.assertEqual(self.mock_ws_send.call_count, 2)
+        _, message_type, message_data = self.mock_ws_send.call_args[0]
+        self.assertEqual(message_type, WebSocketMessageType.ALBUM_CREATED)
+        self.assertEqual(message_data, {"data": self.serialized_data})
+
+
 class TestAlbumServiceModifyAlbum(unittest.TestCase):
     """Tests for AlbumService.modifyAlbum method."""
 
@@ -179,6 +221,14 @@ class TestAlbumServiceModifyAlbum(unittest.TestCase):
             "cover_image": TEST_NEW_COVER_IMAGE_URL,
         }
 
+        ws_patcher = patch("core.services.album_service.send_ws_message_to_user")
+        user_patcher = patch("core.services.album_service.User")
+        self.mock_ws_send = ws_patcher.start()
+        mock_user_model = user_patcher.start()
+        mock_user_model.objects.all.return_value.values_list.return_value = [1, 2]
+        self.addCleanup(ws_patcher.stop)
+        self.addCleanup(user_patcher.stop)
+
     @patch("core.services.album_service.AlbumSerializer")
     @patch("core.services.album_service.photo_repository")
     @patch("core.services.album_service.get_object_or_404")
@@ -198,13 +248,28 @@ class TestAlbumServiceModifyAlbum(unittest.TestCase):
 
         self.assertEqual(result, self.serialized_data)
 
+    @patch("core.services.album_service.AlbumSerializer")
+    @patch("core.services.album_service.photo_repository")
     @patch("core.services.album_service.get_object_or_404")
-    def test_modifyAlbum_without_image_raises_not_found(self, mock_get_object):
-
+    def test_modifyAlbum_without_image_updates_other_fields(
+        self, mock_get_object, mock_photo_repo, mock_serializer_class
+    ):
+        # Editing title/description without a new cover must succeed
         mock_get_object.return_value = self.mock_album
+        mock_serializer = MagicMock()
+        mock_serializer.is_valid.return_value = True
+        mock_serializer.data = self.serialized_data
+        mock_serializer_class.return_value = mock_serializer
 
-        with self.assertRaises(NotFound):
-            AlbumService.modifyAlbum(TEST_ALBUM_ID, self.raw_data, self.empty_file_dict)
+        result = AlbumService.modifyAlbum(
+            TEST_ALBUM_ID, self.raw_data, self.empty_file_dict
+        )
+
+        self.assertEqual(result, self.serialized_data)
+        mock_photo_repo.delete.assert_not_called()
+        mock_photo_repo.save.assert_not_called()
+        data_passed = mock_serializer_class.call_args[1]["data"]
+        self.assertNotIn("cover_image", data_passed)
 
     @patch("core.services.album_service.AlbumSerializer")
     @patch("core.services.album_service.photo_repository")
@@ -283,6 +348,49 @@ class TestAlbumServiceModifyAlbum(unittest.TestCase):
             AlbumService.modifyAlbum(TEST_ALBUM_ID, {"title": ""}, self.file_dict)
 
 
+class TestAlbumServiceModifyAlbumBroadcast(unittest.TestCase):
+    """Tests for the ALBUM_UPDATED WebSocket broadcast."""
+
+    def setUp(self):
+        self.mock_album = MagicMock()
+        self.mock_album.id = TEST_ALBUM_ID
+        self.mock_album.cover_image = TEST_COVER_IMAGE_URL
+        self.serialized_data = {"id": TEST_ALBUM_ID, "title": "Updated Title"}
+
+        ws_patcher = patch("core.services.album_service.send_ws_message_to_user")
+        user_patcher = patch("core.services.album_service.User")
+        self.mock_ws_send = ws_patcher.start()
+        mock_user_model = user_patcher.start()
+        mock_user_model.objects.all.return_value.values_list.return_value = [1, 2]
+        self.addCleanup(ws_patcher.stop)
+        self.addCleanup(user_patcher.stop)
+
+    @patch("core.services.album_service.AlbumSerializer")
+    @patch("core.services.album_service.photo_repository")
+    @patch("core.services.album_service.get_object_or_404")
+    def test_modifyAlbum_broadcasts_album_updated_event(
+        self, mock_get_object, mock_photo_repo, mock_serializer_class
+    ):
+        mock_get_object.return_value = self.mock_album
+        mock_photo_repo.delete.return_value = True
+        mock_photo_repo.save.return_value = TEST_NEW_COVER_IMAGE_URL
+        mock_serializer = MagicMock()
+        mock_serializer.is_valid.return_value = True
+        mock_serializer.data = self.serialized_data
+        mock_serializer_class.return_value = mock_serializer
+
+        mock_file = MagicMock()
+        mock_file.name = TEST_FILE_NAME
+        AlbumService.modifyAlbum(
+            TEST_ALBUM_ID, {"title": "Updated Title"}, {"image": mock_file}
+        )
+
+        self.assertEqual(self.mock_ws_send.call_count, 2)
+        _, message_type, message_data = self.mock_ws_send.call_args[0]
+        self.assertEqual(message_type, WebSocketMessageType.ALBUM_UPDATED)
+        self.assertEqual(message_data, {"data": self.serialized_data})
+
+
 class TestAlbumServiceReplaceCoverImage(unittest.TestCase):
     """Tests for AlbumService._replace_cover_image method."""
 
@@ -339,13 +447,16 @@ class TestAlbumServiceReplaceCoverImage(unittest.TestCase):
 
         mock_album = MagicMock()
         mock_album.cover_image = None
+        mock_photo_repo.save.return_value = TEST_NEW_COVER_IMAGE_URL
 
         result = AlbumService._replace_cover_image(
             self.data, mock_album, self.file_dict
         )
 
         mock_photo_repo.delete.assert_not_called()
-        self.assertEqual(result, self.data)
+        # The new cover must still be uploaded and set
+        mock_photo_repo.save.assert_called_once_with(self.mock_file)
+        self.assertEqual(result["cover_image"], TEST_NEW_COVER_IMAGE_URL)
 
     @patch("core.services.album_service.photo_repository")
     def test_replace_cover_image_when_empty_cover_does_not_delete(
@@ -354,13 +465,15 @@ class TestAlbumServiceReplaceCoverImage(unittest.TestCase):
 
         mock_album = MagicMock()
         mock_album.cover_image = ""
+        mock_photo_repo.save.return_value = TEST_NEW_COVER_IMAGE_URL
 
         result = AlbumService._replace_cover_image(
             self.data, mock_album, self.file_dict
         )
 
         mock_photo_repo.delete.assert_not_called()
-        self.assertEqual(result, self.data)
+        mock_photo_repo.save.assert_called_once_with(self.mock_file)
+        self.assertEqual(result["cover_image"], TEST_NEW_COVER_IMAGE_URL)
 
 
 if __name__ == "__main__":

--- a/frontend/src/components/AlbumsGrid.tsx
+++ b/frontend/src/components/AlbumsGrid.tsx
@@ -2,9 +2,11 @@ import React from "react"
 import { Box } from "@mui/material"
 import AlbumCard from "./AlbumCard"
 import { useAlbums } from "../queries/albums"
+import { useAlbumsWebSocketSync } from "../hooks/useAlbumsWebSocketSync"
 
 function AlbumsGrid() {
     const { data: albums = [] } = useAlbums()
+    useAlbumsWebSocketSync()
 
     return (
         <Box

--- a/frontend/src/hooks/useAlbumsWebSocketSync.ts
+++ b/frontend/src/hooks/useAlbumsWebSocketSync.ts
@@ -1,0 +1,36 @@
+import { useEffect } from "react"
+import { useQueryClient } from "@tanstack/react-query"
+import { useWebSocketContext } from "../contexts/WebSocketProvider"
+import { WebSocketMessageType } from "../types/websockets"
+
+// Album and photo events that can change the albums list
+// (photo events affect nb_photos and cover freshness)
+const ALBUM_RELATED_EVENTS = [
+    WebSocketMessageType.AlbumCreated,
+    WebSocketMessageType.AlbumUpdated,
+    WebSocketMessageType.PhotoUploaded,
+    WebSocketMessageType.PhotoDeleted,
+    WebSocketMessageType.PhotoMoved,
+    WebSocketMessageType.PhotoCopied,
+]
+
+/**
+ * Keeps the react-query "albums" cache in sync with WebSocket events.
+ * Any album or photo change triggers a refetch of the albums list.
+ */
+export function useAlbumsWebSocketSync(): void {
+    const websocket = useWebSocketContext()
+    const queryClient = useQueryClient()
+
+    useEffect(() => {
+        const invalidateAlbums = () => {
+            queryClient.invalidateQueries({ queryKey: ["albums"] })
+        }
+
+        ALBUM_RELATED_EVENTS.forEach((event) => websocket.bind(event, invalidateAlbums))
+
+        return () => {
+            ALBUM_RELATED_EVENTS.forEach((event) => websocket.unbind(event, invalidateAlbums))
+        }
+    }, [websocket, queryClient])
+}

--- a/frontend/src/hooks/usePhotosWithWebSocket.ts
+++ b/frontend/src/hooks/usePhotosWithWebSocket.ts
@@ -2,7 +2,13 @@ import { useEffect, useState, useCallback } from "react"
 import { useGetPhotos } from "../queries/photos"
 import { useWebSocketContext } from "../contexts/WebSocketProvider"
 import { WebSocketMessageType } from "../types/websockets"
-import { PhotoUploaded, PhotoDeleted, PhotoUpdated } from "../types/websocket-interfaces"
+import {
+    PhotoUploaded,
+    PhotoDeleted,
+    PhotoUpdated,
+    PhotoMoved,
+    PhotoCopied,
+} from "../types/websocket-interfaces"
 import { Photo } from "../types/photo"
 
 interface UsePhotosWithWebSocketResult {
@@ -81,18 +87,66 @@ export function usePhotosWithWebSocket(albumId: string): UsePhotosWithWebSocketR
         [albumId]
     )
 
+    // Handle photo moved event: remove from source album, add to target album
+    const handlePhotoMoved = useCallback(
+        (payload: PhotoMoved) => {
+            if (String(payload.source_album_id) === String(albumId)) {
+                console.debug("Photo moved out via WebSocket:", payload.data.id)
+                setPhotos((prev) => prev.filter((photo) => photo.id !== payload.data.id))
+            } else if (String(payload.target_album_id) === String(albumId)) {
+                console.debug("Photo moved in via WebSocket:", payload.data.id)
+                setPhotos((prev) => {
+                    if (prev.some((p) => p.id === payload.data.id)) {
+                        return prev
+                    }
+                    return [payload.data, ...prev]
+                })
+            }
+        },
+        [albumId]
+    )
+
+    // Handle photo copied event: add the new photo to the target album
+    const handlePhotoCopied = useCallback(
+        (payload: PhotoCopied) => {
+            if (String(payload.album_id) !== String(albumId)) {
+                return
+            }
+
+            console.debug("Photo copied via WebSocket:", payload.data.id)
+            setPhotos((prev) => {
+                if (prev.some((p) => p.id === payload.data.id)) {
+                    return prev
+                }
+                return [payload.data, ...prev]
+            })
+        },
+        [albumId]
+    )
+
     // Subscribe to WebSocket events
     useEffect(() => {
         websocket.bind(WebSocketMessageType.PhotoUploaded, handlePhotoUploaded)
         websocket.bind(WebSocketMessageType.PhotoDeleted, handlePhotoDeleted)
         websocket.bind(WebSocketMessageType.PhotoUpdated, handlePhotoUpdated)
+        websocket.bind(WebSocketMessageType.PhotoMoved, handlePhotoMoved)
+        websocket.bind(WebSocketMessageType.PhotoCopied, handlePhotoCopied)
 
         return () => {
             websocket.unbind(WebSocketMessageType.PhotoUploaded, handlePhotoUploaded)
             websocket.unbind(WebSocketMessageType.PhotoDeleted, handlePhotoDeleted)
             websocket.unbind(WebSocketMessageType.PhotoUpdated, handlePhotoUpdated)
+            websocket.unbind(WebSocketMessageType.PhotoMoved, handlePhotoMoved)
+            websocket.unbind(WebSocketMessageType.PhotoCopied, handlePhotoCopied)
         }
-    }, [websocket, handlePhotoUploaded, handlePhotoDeleted, handlePhotoUpdated])
+    }, [
+        websocket,
+        handlePhotoUploaded,
+        handlePhotoDeleted,
+        handlePhotoUpdated,
+        handlePhotoMoved,
+        handlePhotoCopied,
+    ])
 
     return {
         photos,


### PR DESCRIPTION
This pull request introduces real-time synchronization for album and photo changes across users using WebSockets. The backend now broadcasts album creation and update events to all users, and the frontend listens for these events to keep the album and photo lists up to date. Additionally, photo move and copy events are handled for per-album updates. Comprehensive tests were added to ensure correct WebSocket broadcasting and event handling.

**Backend: WebSocket Integration and Album Service Changes**
- Album creation and update operations now broadcast WebSocket events (`ALBUM_CREATED`, `ALBUM_UPDATED`) to all authenticated users, ensuring all clients stay in sync with album changes.
- Refactored album cover image logic: updating album details no longer requires an image, and cover image uploads always update the field if present.
- Tests were added and updated to verify that WebSocket broadcasts are sent on album create/update and that image logic works as expected.

**Frontend: Real-Time Album and Photo List Synchronization**
- Introduced the `useAlbumsWebSocketSync` hook, which listens for album- and photo-related WebSocket events and automatically refetches the albums list when relevant changes occur. This hook is now used in `AlbumsGrid`. 
- Enhanced the `usePhotosWithWebSocket` hook to handle `PhotoMoved` and `PhotoCopied` events, updating per-album photo lists in real time when photos are moved or copied between albums. 

These changes ensure that all users see up-to-date album and photo information without needing to refresh the page.Every album/photo change now updates all connected clients instantly, without a manual reload.

Backend:
- AlbumService broadcasts ALBUM_CREATED and ALBUM_UPDATED (the photo events were already broadcast; album events existed in the enum but were never emitted — resolves the old TODO in modifyAlbum)

Frontend:
- New useAlbumsWebSocketSync hook (used by AlbumsGrid): any album or photo event invalidates the react-query albums cache, keeping covers and photo counts fresh
- usePhotosWithWebSocket now handles PHOTO_MOVED (removed from source album, added to target) and PHOTO_COPIED, which the backend emitted but the client ignored